### PR TITLE
Working implementation of timeout in StateInteger

### DIFF
--- a/Csp/Integer/StateInteger.cs
+++ b/Csp/Integer/StateInteger.cs
@@ -148,7 +148,6 @@ namespace Decider.Csp.Integer
 						throw new DeciderException("No solution found.");
 					}
 
-					startTime = DateTime.Now;
 					Search(out searchResult, unassignedVariables, instantiatedVariables, startTime, timeOut);
 
 					this.ConstraintList.RemoveAt(this.ConstraintList.Count - 1);
@@ -191,13 +190,13 @@ namespace Decider.Csp.Integer
 
 				if (ConstraintsViolated() || unassignedVariables.Any(v => v.Size() == 0))
 				{
-					if ((DateTime.Now - startTime).Seconds > timeOut)
-						throw new DeciderException();
-
 					Backtrack(unassignedVariables, instantiatedVariables);
 				}
 
-				++this.Depth;
+                if ((DateTime.Now - startTime).TotalSeconds > timeOut)
+                    throw new DeciderException();
+
+                ++this.Depth;
 			}
 		}
 


### PR DESCRIPTION
The current implementation of 'Search' and 'StartSearch' in the 'StateInteger' class is invalid.

- The 'Seconds' method of 'TimeSpan' was used instead of 'TotalSeconds'
- The start time of the search was reset on every loop
- The timeout was only checked as part of a conditional rather than unconditionally

The result of these changes means that running the search with a timeout of 20 will not run longer than 20 seconds.