### PR TITLE
Target netstandard 2.0

### DIFF
--- a/Csp/AllDifferentInteger/AllDifferentInteger.csproj
+++ b/Csp/AllDifferentInteger/AllDifferentInteger.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Decider.Csp.Global</RootNamespace>
     <AssemblyName>Decider.Csp.Global.AllDifferentInteger</AssemblyName>
   </PropertyGroup>

--- a/Csp/BaseTypes/BaseTypes.csproj
+++ b/Csp/BaseTypes/BaseTypes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Decider.Csp.BaseTypes</RootNamespace>
     <AssemblyName>Decider.Csp.BaseTypes</AssemblyName>
   </PropertyGroup>

--- a/Csp/Integer/Integer.csproj
+++ b/Csp/Integer/Integer.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Decider.Csp.Integer</RootNamespace>
     <AssemblyName>Decider.Csp.Integer</AssemblyName>
   </PropertyGroup>


### PR DESCRIPTION
Changed the TargetFramework to netstandard2.0. This makes it easier to consume the NuGet package from both the full .NET Framework and .NET Core.

It also makes more sense when referencing Decider in another project because we are targeting a [specification)](https://docs.microsoft.com/en-us/dotnet/standard/net-standard) (netstandard and not an implementation (.NET Framework/Core).

