### PR TITLE
bugfix:Check bounds in AND operator propagator.

### DIFF
--- a/Csp/Integer/ExpressionInteger.cs
+++ b/Csp/Integer/ExpressionInteger.cs
@@ -285,7 +285,7 @@ namespace Decider.Csp.Integer
 						{
 							if (second.Bounds.LowerBound > 0)
 								result = ConstraintOperationResult.Violated;
-							else
+							else if (second.Bounds.UpperBound == 1)
 							{
 								second.Bounds.UpperBound = 0;
 								result = ConstraintOperationResult.Propagated;
@@ -296,7 +296,7 @@ namespace Decider.Csp.Integer
 						{
 							if (second.Bounds.LowerBound > 0)
 								result = ConstraintOperationResult.Violated;
-							else
+							else if (first.Bounds.UpperBound == 1)
 							{
 								first.Bounds.UpperBound = 0;
 								result = ConstraintOperationResult.Propagated;


### PR DESCRIPTION
Bugfix to the AND (&) operator. If a boolean variable's domain should be updated to [0, 0] and it already _was_ that value, the code would still mark the domain as being changed (propagated). This would start an infinite loop. Checking to see if the bounds were already satisfied before propagating has fixed this error.
