### PR TITLE
Add meta expression enabling creation of meta constraints.

### DIFF
--- a/Csp/AllDifferentInteger/AllDifferentInteger.csproj
+++ b/Csp/AllDifferentInteger/AllDifferentInteger.csproj
@@ -1,6 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <GenerateResourceNeverLockTypeAssemblies>true</GenerateResourceNeverLockTypeAssemblies>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Decider.Csp.Global</RootNamespace>
     <AssemblyName>Decider.Csp.Global.AllDifferentInteger</AssemblyName>

--- a/Csp/BaseTypes/BaseTypes.csproj
+++ b/Csp/BaseTypes/BaseTypes.csproj
@@ -1,6 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <GenerateResourceNeverLockTypeAssemblies>true</GenerateResourceNeverLockTypeAssemblies>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Decider.Csp.BaseTypes</RootNamespace>
     <AssemblyName>Decider.Csp.BaseTypes</AssemblyName>

--- a/Csp/Integer/ConstrainedArray.cs
+++ b/Csp/Integer/ConstrainedArray.cs
@@ -13,13 +13,13 @@ namespace Decider.Csp.BaseTypes
 	{
 		private VariableInteger Index { get; set; }
 
-		public ExpressionInteger this[VariableInteger index]
+		public MetaExpressionInteger this[VariableInteger index]
 		{
 			get
 			{
 				Index = index;
 
-				return new ExpressionInteger(GetVariableInteger(), this.Evaluate, this.EvaluateBounds, this.Propagator);
+				return new MetaExpressionInteger(GetVariableInteger(), this.Evaluate, this.EvaluateBounds, this.Propagator, new[] { Index });
 			}
 		}
 

--- a/Csp/Integer/ConstraintInteger.cs
+++ b/Csp/Integer/ConstraintInteger.cs
@@ -103,11 +103,6 @@ namespace Decider.Csp.Integer
 
 		bool IConstraint.StateChanged()
 		{
-			// what is variableArray?
-			// what is domainArray?
-			// these are apparently the same, so it doesn't look like the state has changed...
-			// ...so this constraint is ruled out as one worth testing...
-			// ...so despite it being violated, the program continues on regardless.
 			return this.variableArray.Where((variable, index) => ((VariableInteger) variable)
 				.Domain != this.domainArray[index]).Any();
 		}

--- a/Csp/Integer/ConstraintInteger.cs
+++ b/Csp/Integer/ConstraintInteger.cs
@@ -35,14 +35,39 @@ namespace Decider.Csp.Integer
 		private static void ConstructVariableList(ExpressionInteger expression, ISet<IVariable<int>> variableSet)
 		{
 			if (expression.Left is VariableInteger)
+			{
 				variableSet.Add((VariableInteger) expression.Left);
-			else if (expression.Left is ExpressionInteger)
+			}
+			else if (expression.Left is MetaExpressionInteger)
+			{
 				ConstructVariableList((ExpressionInteger) expression.Left, variableSet);
+				foreach (var variable in ((IMetaExpression<int>) expression.Left).Support)
+				{
+					variableSet.Add(variable);
+				}
+			}
+			else if (expression.Left is ExpressionInteger)
+			{
+				ConstructVariableList((ExpressionInteger) expression.Left, variableSet);
+			}
+
 
 			if (expression.Right is VariableInteger)
+			{
 				variableSet.Add((VariableInteger) expression.Right);
-			else if (expression.Right is ExpressionInteger)
+			}
+			else if (expression.Right is MetaExpressionInteger)
+			{
 				ConstructVariableList((ExpressionInteger) expression.Right, variableSet);
+				foreach (var variable in ((IMetaExpression<int>) expression.Right).Support)
+				{
+					variableSet.Add(variable);
+				}
+			}
+			else if (expression.Right is ExpressionInteger)
+			{
+				ConstructVariableList((ExpressionInteger) expression.Right, variableSet);
+			}
 		}
 
 		void IConstraint.Check(out ConstraintOperationResult result)
@@ -78,6 +103,11 @@ namespace Decider.Csp.Integer
 
 		bool IConstraint.StateChanged()
 		{
+			// what is variableArray?
+			// what is domainArray?
+			// these are apparently the same, so it doesn't look like the state has changed...
+			// ...so this constraint is ruled out as one worth testing...
+			// ...so despite it being violated, the program continues on regardless.
 			return this.variableArray.Where((variable, index) => ((VariableInteger) variable)
 				.Domain != this.domainArray[index]).Any();
 		}

--- a/Csp/Integer/Integer.csproj
+++ b/Csp/Integer/Integer.csproj
@@ -1,6 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <GenerateResourceNeverLockTypeAssemblies>true</GenerateResourceNeverLockTypeAssemblies>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Decider.Csp.Integer</RootNamespace>
     <AssemblyName>Decider.Csp.Integer</AssemblyName>

--- a/Examples/Optimisation/Optimisation.cs
+++ b/Examples/Optimisation/Optimisation.cs
@@ -26,7 +26,7 @@ namespace Decider.Example.Optimisation
 			var h = new VariableInteger("h", 0, 9);
 			var optimise = new VariableInteger("optimise", 0, 72);
 
-			var array = new ConstrainedArray(new int[] { 0, 23, 52, 62, 75, 73, 47, 20, 87, 27 });
+			var array = new ConstrainedArray(new int[] { 60, 52, 52, 62, 35, 73, 47, 20, 87, 27 });
 
 			var constraints = new List<IConstraint>
 				{
@@ -42,7 +42,7 @@ namespace Decider.Example.Optimisation
 			var variables = new[] { a, b, c, d, e, f, g, h, optimise };
 			IState<int> state = new StateInteger(variables, constraints);
 
-			state.StartSearch(out StateOperationResult searchResult, optimise, out IDictionary<string, IVariable<int>> solution, 2);
+			state.StartSearch(out StateOperationResult searchResult, optimise, out IDictionary<string, IVariable<int>> solution, 20);
 
 			Console.WriteLine("a: {0}", solution["a"]);
 			Console.WriteLine("b: {0}", solution["b"]);

--- a/csp/BaseTypes/MetaExpression.cs
+++ b/csp/BaseTypes/MetaExpression.cs
@@ -1,0 +1,18 @@
+﻿/*
+  Copyright © Iain McDonald 2010-2019
+  
+  This file is part of Decider.
+
+  Unlike the Expression type which is wholly supported on its own, the MetaExpression relies
+  on the values of other supporting variables. Thus, if those variables change, the bounds
+  of the MetaExpression need to be re-evaluated.
+*/
+using System.Collections.Generic;
+
+namespace Decider.Csp.BaseTypes
+{
+	public interface IMetaExpression<T>
+	{
+		IList<IVariable<T>> Support { get; }
+	}
+}

--- a/csp/Integer/MetaExpressionInteger.cs
+++ b/csp/Integer/MetaExpressionInteger.cs
@@ -1,0 +1,46 @@
+﻿/*
+  Copyright © Iain McDonald 2010-2019
+  
+  This file is part of Decider.
+*/
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Decider.Csp.BaseTypes;
+
+namespace Decider.Csp.Integer
+{
+	public class MetaExpressionInteger : ExpressionInteger, IMetaExpression<int>
+	{
+		private readonly IList<IVariable<int>> support;
+
+		IList<IVariable<int>> IMetaExpression<int>.Support
+		{
+			get { return this.support; }
+		}
+
+		public MetaExpressionInteger(Expression<int> left, Expression<int> right, IEnumerable<IVariable<int>> support)
+			: base(left, right)
+		{
+			this.support = support.ToList();
+		}
+
+		public MetaExpressionInteger(int integer, IEnumerable<IVariable<int>> support)
+			: base(integer)
+		{
+			this.support = support.ToList();
+		}
+
+		internal MetaExpressionInteger(VariableInteger variable,
+			Func<ExpressionInteger, ExpressionInteger, int> evaluate,
+			Func<ExpressionInteger, ExpressionInteger, Bounds<int>> evaluateBounds,
+			Func<ExpressionInteger, ExpressionInteger, Bounds<int>, ConstraintOperationResult> propagator,
+			IEnumerable<IVariable<int>> support)
+			: base(variable, evaluate, evaluateBounds, propagator)
+		{
+			this.support = support.ToList();
+		}
+
+	}
+}


### PR DESCRIPTION
The constrained array type allows constrained variables to index arrays, providing a rich syntax for describing CSPs. For example, given the variable var_i, with domain [0..5], the user can create an array of exponents and use it to make a constraint:
```
exponentArray = [1, 10, 100, 1000, 10000, 100000]
constraint = exponentArray[var_i] < 500
```
Decider examines the contents of each constraint ahead of search and makes a list of the support variables. This is used when checking constraint consistency: if no changes to variables that support a constraint have been made, the constraint does not need to be checked.

Before the implementation of MetaExpressions, the above constraint parsing would look at `constraint` (defined above) and rule that the implicit expression created by indexing `exponentArray` is the only variable that needs to be tracked. This is incorrect. The `var_i` variable needs to be tracked as well, which the introduction of MetaExpressions now does.
