### PR TITLE
Prune value from Variable, not Domain.

### DIFF
--- a/Csp/Integer/ConstrainedArray.cs
+++ b/Csp/Integer/ConstrainedArray.cs
@@ -95,13 +95,11 @@ namespace Decider.Csp.BaseTypes
 			{
 				result = ConstraintOperationResult.Propagated;
 
-				var domainOperation = default(DomainOperationResult);
-
 				foreach (var value in remove)
 				{
-					Index.Domain.Remove(value, out domainOperation);
+					((IVariable<int>) Index).Remove(value, out DomainOperationResult domainResult);
 
-					if (domainOperation == DomainOperationResult.EmptyDomain)
+					if (domainResult == DomainOperationResult.EmptyDomain)
 						return ConstraintOperationResult.Violated;
 				}
 

--- a/Csp/Integer/ConstrainedArray.cs
+++ b/Csp/Integer/ConstrainedArray.cs
@@ -97,9 +97,9 @@ namespace Decider.Csp.BaseTypes
 
 				foreach (var value in remove)
 				{
-					((IVariable<int>) Index).Remove(value, out DomainOperationResult domainResult);
+					((IVariable<int>) Index).Remove(value, out DomainOperationResult domainOperation);
 
-					if (domainResult == DomainOperationResult.EmptyDomain)
+					if (domainOperation == DomainOperationResult.EmptyDomain)
 						return ConstraintOperationResult.Violated;
 				}
 

--- a/Csp/Integer/StateInteger.cs
+++ b/Csp/Integer/StateInteger.cs
@@ -153,8 +153,6 @@ namespace Decider.Csp.Integer
 					this.ConstraintList.RemoveAt(this.ConstraintList.Count - 1);
 					this.ConstraintList.Add(new ConstraintInteger((VariableInteger) optimiseVar > optimiseVar.InstantiatedValue));
 
-					// Console.WriteLine("Optimised Value: {0} ({1}s)", optimiseVar.InstantiatedValue, DateTime.Now - startTime);
-
 					solution = this.LastSolution.Select(v => v.Clone())
 						.Cast<IVariable<int>>()
 						.Select(v => new KeyValuePair<string, IVariable<int>>(v.Name, v))


### PR DESCRIPTION
In order to save expensive domain copy operations, Decider only copies the domain of a variable if the variable is instantiated or inference (propagation) alters the domain. A stack maintains the domain copies, each with the depth in the search tree where the modification took place.

A bug was introduced during the creation of the ConstrainedArray type. When it performed domaining pruning, it went straight to the most recent domain and removed values. This had the effect that search inference performed deep in the tree, appeared to take place nearer the root than it did.

This fix ensures that the Variable class prunes the domain values because it will create a copy of the domain for the stack if necessary.