### PR TITLE
Usability improvements

### DIFF
--- a/Csp/Global/AllDifferentInteger.cs
+++ b/Csp/Global/AllDifferentInteger.cs
@@ -37,7 +37,7 @@ namespace Decider.Csp.Global
 			this.cycleDetection = new CycleDetection();
 		}
 
-		void IConstraint.Check(out ConstraintOperationResult result)
+		public void Check(out ConstraintOperationResult result)
 		{
 			for (var i = 0; i < this.variableArray.Length; ++i)
 				this.domainArray[i] = variableArray[i].Domain;
@@ -62,7 +62,7 @@ namespace Decider.Csp.Global
 			return this.Graph.MaximalMatching() >= this.variableArray.Length;
 		}
 
-		void IConstraint.Propagate(out ConstraintOperationResult result)
+		public void Propagate(out ConstraintOperationResult result)
 		{
 			this.Graph = new BipartiteGraph(this.variableArray);
 
@@ -90,7 +90,7 @@ namespace Decider.Csp.Global
 					{
 						result = ConstraintOperationResult.Propagated;
 
-						((IVariable<int>) variable).Remove(value, this.Depth, out DomainOperationResult domainResult);
+						variable.Remove(value, this.Depth, out DomainOperationResult domainResult);
 
 						if (domainResult != DomainOperationResult.EmptyDomain)
 							continue;
@@ -102,7 +102,7 @@ namespace Decider.Csp.Global
 			}
 		}
 
-		bool IConstraint.StateChanged()
+		public bool StateChanged()
 		{
 			return this.variableArray.Where((t, i) => t.Domain != this.domainArray[i]).Any();
 		}

--- a/Csp/Integer/ConstrainedArray.cs
+++ b/Csp/Integer/ConstrainedArray.cs
@@ -97,7 +97,7 @@ namespace Decider.Csp.BaseTypes
 
 				foreach (var value in remove)
 				{
-					((IVariable<int>) Index).Remove(value, out DomainOperationResult domainOperation);
+					Index.Remove(value, out DomainOperationResult domainOperation);
 
 					if (domainOperation == DomainOperationResult.EmptyDomain)
 						return ConstraintOperationResult.Violated;

--- a/Csp/Integer/ConstraintInteger.cs
+++ b/Csp/Integer/ConstraintInteger.cs
@@ -70,7 +70,7 @@ namespace Decider.Csp.Integer
 			}
 		}
 
-		void IConstraint.Check(out ConstraintOperationResult result)
+		public void Check(out ConstraintOperationResult result)
 		{
 			for (var i = 0; i < this.variableArray.Length; ++i)
 				this.domainArray[i] = ((VariableInteger) variableArray[i]).Domain;
@@ -91,7 +91,7 @@ namespace Decider.Csp.Integer
 			}
 		}
 
-		void IConstraint.Propagate(out ConstraintOperationResult result)
+		public void Propagate(out ConstraintOperationResult result)
 		{
 			var enforce = new Bounds<int>(1, 1);
 
@@ -101,7 +101,7 @@ namespace Decider.Csp.Integer
 			} while ((result &= ConstraintOperationResult.Propagated) == ConstraintOperationResult.Propagated);
 		}
 
-		bool IConstraint.StateChanged()
+		public bool StateChanged()
 		{
 			return this.variableArray.Where((variable, index) => ((VariableInteger) variable)
 				.Domain != this.domainArray[index]).Any();

--- a/Csp/Integer/DomainBinaryInteger.cs
+++ b/Csp/Integer/DomainBinaryInteger.cs
@@ -28,7 +28,7 @@ namespace Decider.Csp.Integer
 		private int size;
 		private int offset;
 
-		bool IDomain<int>.Contains(int index)
+		public bool Contains(int index)
 		{
 			return IsInDomain(index);
 		}
@@ -112,23 +112,23 @@ namespace Decider.Csp.Integer
 
 		#region IDomain<int> Members
 
-		int IDomain<int>.InstantiatedValue
+		public int InstantiatedValue
 		{
 			get
 			{
-				if (!((IDomain<int>) this).Instantiated())
+				if (!Instantiated())
 					throw new DeciderException("Trying to access InstantiatedValue of an uninstantiated domain.");
 
 				return this.lowerBound - offset;
 			}
 		}
 
-		void IDomain<int>.Instantiate(out DomainOperationResult result)
+		public void Instantiate(out DomainOperationResult result)
 		{
-			((IDomain<int>) this).InstantiateLowest(out result);
+			InstantiateLowest(out result);
 		}
 
-		void IDomain<int>.Instantiate(int value, out DomainOperationResult result)
+		public void Instantiate(int value, out DomainOperationResult result)
 		{
 			if (!IsInDomain(value))
 			{
@@ -141,7 +141,7 @@ namespace Decider.Csp.Integer
 			result = DomainOperationResult.InstantiateSuccessful;
 		}
 
-		void IDomain<int>.InstantiateLowest(out DomainOperationResult result)
+		public void InstantiateLowest(out DomainOperationResult result)
 		{
 			if (!IsInDomain(this.lowerBound - offset))
 			{
@@ -154,7 +154,7 @@ namespace Decider.Csp.Integer
 			result = DomainOperationResult.InstantiateSuccessful;
 		}
 
-		void IDomain<int>.Remove(int element, out DomainOperationResult result)
+		public void Remove(int element, out DomainOperationResult result)
 		{
 			result = DomainOperationResult.EmptyDomain;
 			if (element < -offset || !IsInDomain(element))
@@ -195,29 +195,29 @@ namespace Decider.Csp.Integer
 			result = DomainOperationResult.RemoveSuccessful;
 		}
 
-		string IDomain<int>.ToString()
+		public override string ToString()
 		{
 			var domainRange = Enumerable.Range(lowerBound, upperBound - lowerBound + 1).Select(x => x - offset).Where(IsInDomain);
 
 			return "[" + string.Join(", ", domainRange) + "]";
 		}
 
-		bool IDomain<int>.Instantiated()
+		public bool Instantiated()
 		{
 			return this.upperBound == this.lowerBound;
 		}
 
-		int IDomain<int>.Size()
+		public int Size()
 		{
 			return this.size;
 		}
 
-		int IDomain<int>.LowerBound
+		public int LowerBound
 		{
 			get { return this.lowerBound - offset; }
 		}
 
-		int IDomain<int>.UpperBound
+		public int UpperBound
 		{
 			get { return this.upperBound - offset; }
 		}

--- a/Csp/Integer/MetaExpressionInteger.cs
+++ b/Csp/Integer/MetaExpressionInteger.cs
@@ -15,7 +15,7 @@ namespace Decider.Csp.Integer
 	{
 		private readonly IList<IVariable<int>> support;
 
-		IList<IVariable<int>> IMetaExpression<int>.Support
+		public IList<IVariable<int>> Support
 		{
 			get { return this.support; }
 		}
@@ -41,6 +41,5 @@ namespace Decider.Csp.Integer
 		{
 			this.support = support.ToList();
 		}
-
 	}
 }

--- a/Csp/Integer/StateInteger.cs
+++ b/Csp/Integer/StateInteger.cs
@@ -26,14 +26,14 @@ namespace Decider.Csp.Integer
 
 		public StateInteger(IEnumerable<IVariable<int>> variables, IEnumerable<IConstraint> constraints)
 		{
-			((IState<int>) this).SetVariables(variables);
-			((IState<int>) this).SetConstraints(constraints);
+			SetVariables(variables);
+			SetConstraints(constraints);
 			this.Depth = 0;
 			this.Backtracks = 0;
 			this.Runtime = new TimeSpan(0);
 		}
 
-		void IState<int>.SetVariables(IEnumerable<IVariable<int>> variableList)
+		public void SetVariables(IEnumerable<IVariable<int>> variableList)
 		{
 			this.Variables = variableList.ToList();
 
@@ -41,12 +41,12 @@ namespace Decider.Csp.Integer
 				variable.SetState(this);
 		}
 
-		void IState<int>.SetConstraints(IEnumerable<IConstraint> constraints)
+		public void SetConstraints(IEnumerable<IConstraint> constraints)
 		{
 			this.Constraints = constraints.ToList();
 		}
 
-		void IState<int>.StartSearch(out StateOperationResult searchResult)
+		public void StartSearch(out StateOperationResult searchResult)
 		{
 			var unassignedVariables = this.LastSolution == null
 				? new LinkedList<IVariable<int>>(this.Variables)
@@ -77,7 +77,7 @@ namespace Decider.Csp.Integer
 			}
 		}
 
-		void IState<int>.StartSearch(out StateOperationResult searchResult,
+		public void StartSearch(out StateOperationResult searchResult,
 			out IList<IDictionary<string, IVariable<int>>> solutions)
 		{
 			var unassignedVariables = this.LastSolution == null
@@ -122,7 +122,8 @@ namespace Decider.Csp.Integer
 			solutions = solutionsList;
 		}
 
-		void IState<int>.StartSearch(out StateOperationResult searchResult, IVariable<int> optimiseVar, out IDictionary<string, IVariable<int>> solution, int timeOut)
+		public void StartSearch(out StateOperationResult searchResult, IVariable<int> optimiseVar,
+			out IDictionary<string, IVariable<int>> solution, int timeOut)
 		{
 			var unassignedVariables = this.LastSolution == null
 				? new LinkedList<IVariable<int>>(this.Variables)

--- a/Csp/Integer/VariableInteger.cs
+++ b/Csp/Integer/VariableInteger.cs
@@ -27,7 +27,7 @@ namespace Decider.Csp.Integer
 
 			public object Clone()
 			{
-				return new DomInt((IDomain<int>) this.Domain.Clone(), this.Depth);
+				return new DomInt(this.Domain.Clone(), this.Depth);
 			}
 		}
 
@@ -51,7 +51,7 @@ namespace Decider.Csp.Integer
 			this.remove = prune =>
 			{
 				DomainOperationResult result;
-				((IVariable<int>) this).Remove(prune, out result);
+				Remove(prune, out result);
 				return result;
 			};
 		}
@@ -72,7 +72,7 @@ namespace Decider.Csp.Integer
 			this.domainStack.Push(new DomInt(DomainBinaryInteger.CreateDomain(lowerBound, upperBound), -1));
 		}
 
-		int IVariable<int>.InstantiatedValue
+		public int InstantiatedValue
 		{
 			get
 			{
@@ -80,9 +80,9 @@ namespace Decider.Csp.Integer
 			}
 		}
 
-		void IVariable<int>.Instantiate(int depth, out DomainOperationResult result)
+		public void Instantiate(int depth, out DomainOperationResult result)
 		{
-			var instantiatedDomain = (IDomain<int>) this.Domain.Clone();
+			var instantiatedDomain = this.Domain.Clone();
 			instantiatedDomain.Instantiate(out result);
 			if (result != DomainOperationResult.InstantiateSuccessful)
 				throw new DeciderException("Failed to instantiate Variable.");
@@ -90,9 +90,9 @@ namespace Decider.Csp.Integer
 			this.domainStack.Push(new DomInt(instantiatedDomain, depth));
 		}
 
-		void IVariable<int>.Instantiate(int value, int depth, out DomainOperationResult result)
+		public void Instantiate(int value, int depth, out DomainOperationResult result)
 		{
-			var instantiatedDomain = (IDomain<int>) this.Domain.Clone();
+			var instantiatedDomain = this.Domain.Clone();
 			instantiatedDomain.Instantiate(value, out result);
 			if (result != DomainOperationResult.InstantiateSuccessful)
 				throw new DeciderException("Failed to instantiate Variable.");
@@ -100,17 +100,17 @@ namespace Decider.Csp.Integer
 			this.domainStack.Push(new DomInt(instantiatedDomain, depth));
 		}
 
-		void IVariable<int>.Backtrack(int fromDepth)
+		public void Backtrack(int fromDepth)
 		{
 			while (this.domainStack.Peek().Depth >= fromDepth)
 				this.domainStack.Pop();
 		}
 
-		void IVariable<int>.Remove(int value, int depth, out DomainOperationResult result)
+		public void Remove(int value, int depth, out DomainOperationResult result)
 		{
 			if (this.domainStack.Peek().Depth != depth)
 			{
-				this.domainStack.Push(new DomInt((IDomain<int>) this.Domain.Clone(), depth));
+				this.domainStack.Push(new DomInt(this.Domain.Clone(), depth));
 
 				this.Domain.Remove(value, out result);
 
@@ -121,50 +121,45 @@ namespace Decider.Csp.Integer
 				this.Domain.Remove(value, out result);
 		}
 
-		void IVariable<int>.Remove(int value, out DomainOperationResult result)
+		public void Remove(int value, out DomainOperationResult result)
 		{
-			if (((IVariable<int>) this).Instantiated() || value > this.Domain.UpperBound || value < this.Domain.LowerBound)
+			if (Instantiated() || value > this.Domain.UpperBound || value < this.Domain.LowerBound)
 			{
 				result = DomainOperationResult.ElementNotInDomain;
 				return;
 			}
 
-			((IVariable<int>) this).Remove(value, this.State.Depth, out result);
+			Remove(value, this.State.Depth, out result);
 		}
 
-		string IVariable<int>.ToString()
-		{
-			return this.Domain.ToString();
-		}
-
-		bool IVariable<int>.Instantiated()
+		public bool Instantiated()
 		{
 			return this.Domain.Instantiated();
 		}
 
-		int IVariable<int>.Size()
+		public int Size()
 		{
 			return this.Domain.Size();
 		}
 
-		void IVariable<int>.SetState(IState<int> state)
+		public void SetState(IState<int> state)
 		{
 			this.State = state;
 		}
 
-		int IComparable<IVariable<int>>.CompareTo(IVariable<int> otherVariable)
+		public int CompareTo(IVariable<int> otherVariable)
 		{
-			return ((IVariable<int>) this).Size() - otherVariable.Size();
+			return Size() - otherVariable.Size();
 		}
 
 		public override int Value
 		{
-			get { return ((IVariable<int>) this).InstantiatedValue; }
+			get { return this.InstantiatedValue; }
 		}
 
 		public override bool IsBound
 		{
-			get { return ((IVariable<int>) this).Instantiated(); }
+			get { return Instantiated(); }
 		}
 
 		public override Bounds<int> GetUpdatedBounds()
@@ -191,7 +186,7 @@ namespace Decider.Csp.Integer
 			else
 			{
 				isDomainNew = true;
-				propagatedDomain = (IDomain<int>) domainIntStack.Domain.Clone();
+				propagatedDomain = domainIntStack.Domain.Clone();
 				this.domainStack.Push(new DomInt(propagatedDomain, this.State.Depth));
 			}
 
@@ -217,11 +212,8 @@ namespace Decider.Csp.Integer
 
 		public override string ToString()
 		{
-			//string value = this.IsBound ? ((IVariable<int>) this).InstantiatedValue.ToString() : this.Domain.ToString();
-			//return this.name + ": " + value;
-
 			if (this.IsBound)
-				return ((IVariable<int>) this).InstantiatedValue.ToString(CultureInfo.CurrentCulture);
+				return this.InstantiatedValue.ToString(CultureInfo.CurrentCulture);
 
 			return this.Domain.ToString();
 		}

--- a/Examples/Optimisation/Optimisation.cs
+++ b/Examples/Optimisation/Optimisation.cs
@@ -40,7 +40,7 @@ namespace Decider.Example.Optimisation
 				};
 
 			var variables = new[] { a, b, c, d, e, f, g, h, optimise };
-			IState<int> state = new StateInteger(variables, constraints);
+			var state = new StateInteger(variables, constraints);
 
 			state.StartSearch(out StateOperationResult searchResult, optimise, out IDictionary<string, IVariable<int>> solution, 20);
 

--- a/Examples/PhaseLockedLoop/PhaseLockedLoop.cs
+++ b/Examples/PhaseLockedLoop/PhaseLockedLoop.cs
@@ -59,8 +59,7 @@ namespace Decider.Example.PhaseLockedLoop
 
 
 			//	Search
-			IState<int> state = new StateInteger(new[] { f1, f2, r1, r2, q1, q2 }, constraints);
-
+			var state = new StateInteger(new[] { f1, f2, r1, r2, q1, q2 }, constraints);
 			state.StartSearch(out StateOperationResult searchResult);
 
 			Console.WriteLine("Runtime:\t{0}\nBacktracks:\t{1}\n", state.Runtime, state.Backtracks);

--- a/Examples/SendMoreMoney/SendMoreMoney.cs
+++ b/Examples/SendMoreMoney/SendMoreMoney.cs
@@ -40,7 +40,7 @@ namespace Decider.Example.SendMoreMoney
 				};
 
 			var variables = new [] { c0, c1, c2, c3, s, e, n, d, m, o, r, y };
-			IState<int> state = new StateInteger(variables, constraints);
+			var state = new StateInteger(variables, constraints);
 
 			state.StartSearch(out StateOperationResult searchResult);
 

--- a/Examples/TeacherTimetable/TeacherTimetable.cs
+++ b/Examples/TeacherTimetable/TeacherTimetable.cs
@@ -89,8 +89,7 @@ namespace Decider.Example.TeacherTimetable
 
 			#region Search
 
-			IState<int> state = new StateInteger(Week, constraints);
-
+			var state = new StateInteger(Week, constraints);
 			state.StartSearch(out StateOperationResult searchResult);
 
 			foreach (var period in Week)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Find a solution using Decider's search routines
 
 ```csharp
 var variables = new [] { c0, c1, c2, c3, s, e, n, d, m, o, r, y };
-IState<int> state = new StateInteger(variables, constraints);
+var state = new StateInteger(variables, constraints);
 
 state.StartSearch(out StateOperationResult searchResult);
 


### PR DESCRIPTION
Based on the feedback of user [Jimmacle](https://github.com/Jimmacle )in [this issue](https://github.com/lifebeyondfife/Decider/issues/44), the following improvements have been made:

- solver runtime durations are calculated using System.Diagnostic.Stopwatch rather than multiple snapshots of DateTime.Now
- integer solver classes implement generic solver interfaces as public methods which allows users to access them implicitly, rather than forcing an explicit cast

The above issue also suggested improving the control flow of the search algorithm by no longer throwing exceptions, and dropping use of LINQ. The argument for both was primarily regarding performance, however, in both cases performance is a negligable concern. Exceptions are only thrown in rare / exceptional circumstances, when a problem is unsolveable, or all of the search space has been traversed. Decider is an NP-complete solver and efficiency is concerned with taking multiple seconds or minutes from problem solving. Similarly, dropping LINQ did not result in a noticeable (beyond noise) improvement to runtimes, so I prefer to retain the declarative coding style rather imperative.