### PR TITLE
fix(solver): verify non-empty variable domain

### DIFF
--- a/Csp/Csp.csproj
+++ b/Csp/Csp.csproj
@@ -12,7 +12,7 @@
     <PackageDescription>Simple integer Constraint Programming toolkit for C#</PackageDescription>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/lifebeyondfife/Decider</RepositoryUrl>
-    <Version>0.5.2</Version>
+    <Version>0.5.3</Version>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <Deterministic>true</Deterministic>
   </PropertyGroup>

--- a/Csp/Integer/StateInteger.cs
+++ b/Csp/Integer/StateInteger.cs
@@ -45,7 +45,7 @@ namespace Decider.Csp.Integer
 
 		public void SetConstraints(IEnumerable<IConstraint> constraints)
 		{
-			this.Constraints = constraints.ToList();
+			this.Constraints = constraints?.ToList() ?? new List<IConstraint>();
 		}
 
 		public StateOperationResult Search()
@@ -168,6 +168,11 @@ namespace Decider.Csp.Integer
 			IList<IVariable<int>> instantiatedVariables, ref Stopwatch stopwatch, int timeOut = Int32.MaxValue)
 		{
 			searchResult = StateOperationResult.Unsatisfiable;
+			if (unassignedVariables.Any(x => x.Size() == 0))
+			{
+				this.Depth = -1;
+				return false;
+			}
 
 			while (true)
 			{


### PR DESCRIPTION
Fix for https://github.com/lifebeyondfife/Decider/issues/59.

When enumerating all solutions where there are no constraints, we eventually try to search for a solution using variables with an empty domain. Attempting to instantiate that variable results in a null reference exception.

The solution is validate that no variables have an empty domain (`var.Size == 0`) before beginning search.