### PR TITLE
feat(release): first major version

### DIFF
--- a/Csp/BaseTypes/Constraint.cs
+++ b/Csp/BaseTypes/Constraint.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
   
   This file is part of Decider.
 */

--- a/Csp/BaseTypes/DeciderException.cs
+++ b/Csp/BaseTypes/DeciderException.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
   
   This file is part of Decider.
 */

--- a/Csp/BaseTypes/Domain.cs
+++ b/Csp/BaseTypes/Domain.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
   
   This file is part of Decider.
 */
@@ -28,7 +28,7 @@ namespace Decider.Csp.BaseTypes
 
 		string ToString();
 		bool Instantiated();
-		T Size();
+		int Size();
 		T LowerBound { get; }
 		T UpperBound { get; }
         IDomain<T> Clone();

--- a/Csp/BaseTypes/Expression.cs
+++ b/Csp/BaseTypes/Expression.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
   
   This file is part of Decider.
 */

--- a/Csp/BaseTypes/MetaExpression.cs
+++ b/Csp/BaseTypes/MetaExpression.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
 
   This file is part of Decider.
 

--- a/Csp/BaseTypes/State.cs
+++ b/Csp/BaseTypes/State.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
   
   This file is part of Decider.
 */

--- a/Csp/BaseTypes/Variable.cs
+++ b/Csp/BaseTypes/Variable.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
   
   This file is part of Decider.
 */
@@ -22,7 +22,7 @@ namespace Decider.Csp.BaseTypes
 		string Name { get; }
 		T InstantiatedValue { get; }
 		bool Instantiated();
-		T Size();
+		int Size();
         IVariable<T> Clone();
 	}
 }

--- a/Csp/Csp.csproj
+++ b/Csp/Csp.csproj
@@ -12,7 +12,7 @@
     <PackageDescription>Simple integer Constraint Programming toolkit for C#</PackageDescription>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/lifebeyondfife/Decider</RepositoryUrl>
-    <Version>0.5.4</Version>
+    <Version>1.0.1</Version>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <Deterministic>true</Deterministic>
   </PropertyGroup>

--- a/Csp/Global/AllDifferentInteger.cs
+++ b/Csp/Global/AllDifferentInteger.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
   
   This file is part of Decider.
 */

--- a/Csp/Global/CycleDetection.cs
+++ b/Csp/Global/CycleDetection.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
   
   This file is part of Decider.
 */

--- a/Csp/Global/Graph.cs
+++ b/Csp/Global/Graph.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
   
   This file is part of Decider.
 */

--- a/Csp/Global/Node.cs
+++ b/Csp/Global/Node.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
   
   This file is part of Decider.
 */

--- a/Csp/Integer/ConstrainedArray.cs
+++ b/Csp/Integer/ConstrainedArray.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
   
   This file is part of Decider.
 */

--- a/Csp/Integer/ConstraintInteger.cs
+++ b/Csp/Integer/ConstraintInteger.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
   
   This file is part of Decider.
 */

--- a/Csp/Integer/DomainBinaryInteger.cs
+++ b/Csp/Integer/DomainBinaryInteger.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
   
   This file is part of Decider.
 */

--- a/Csp/Integer/ExpressionInteger.cs
+++ b/Csp/Integer/ExpressionInteger.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
 
   This file is part of Decider.
 */

--- a/Csp/Integer/MetaExpressionInteger.cs
+++ b/Csp/Integer/MetaExpressionInteger.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
 
   This file is part of Decider.
 */

--- a/Csp/Integer/StateInteger.cs
+++ b/Csp/Integer/StateInteger.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
   
   This file is part of Decider.
 */

--- a/Examples/LeagueGeneration/LeagueGeneration.cs
+++ b/Examples/LeagueGeneration/LeagueGeneration.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
   
   This file is part of Decider.
 */

--- a/Examples/LeagueGeneration/Program.cs
+++ b/Examples/LeagueGeneration/Program.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
 
   This file is part of Decider.
 */

--- a/Examples/NQueens/NQueens.cs
+++ b/Examples/NQueens/NQueens.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
   
   This file is part of Decider.
 */

--- a/Examples/NQueens/Program.cs
+++ b/Examples/NQueens/Program.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
 
   This file is part of Decider.
 */

--- a/Examples/PhaseLockedLoop/PhaseLockedLoop.cs
+++ b/Examples/PhaseLockedLoop/PhaseLockedLoop.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
   
   This file is part of Decider.
 */

--- a/Examples/SendMoreMoney/SendMoreMoney.cs
+++ b/Examples/SendMoreMoney/SendMoreMoney.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
   
   This file is part of Decider.
 */

--- a/Examples/TeacherTimetable/TeacherTimetable.cs
+++ b/Examples/TeacherTimetable/TeacherTimetable.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
   
   This file is part of Decider.
 */

--- a/Tests/Acceptance/LeagueGenerationTest.cs
+++ b/Tests/Acceptance/LeagueGenerationTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
 
   This file is part of Decider.
 */

--- a/Tests/Acceptance/NQueensTest.cs
+++ b/Tests/Acceptance/NQueensTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
 
   This file is part of Decider.
 */

--- a/Tests/Unit/ExpressionIntegerTest.cs
+++ b/Tests/Unit/ExpressionIntegerTest.cs
@@ -1,5 +1,5 @@
 /*
-  Copyright © Iain McDonald 2010-2021
+  Copyright © Iain McDonald 2010-2022
 
   This file is part of Decider.
 */


### PR DESCRIPTION
Decider was first used in production for Moody's Analytics insurance enterprise software solutions nearly ten years ago. A number of features, and fixes have gone in since then but the interface has remained stable for a few years now. Time to officially declare a supported major version.